### PR TITLE
#176573803 - Chore: (Rule config) disable space around attr_accessors, and change unused method args to warning 

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -45,6 +45,12 @@ Layout/EmptyLineAfterGuardClause:
 Layout/LineLength:
   Max: 100
 
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Severity: warning
+
 Lint/EmptyBlock:
   Enabled: false
 

--- a/default.yml
+++ b/default.yml
@@ -49,6 +49,7 @@ Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: false
 
 Lint/UnusedMethodArgument:
+  AutoCorrect: false
   Severity: warning
 
 Lint/EmptyBlock:

--- a/lib/style_elmatica/version.rb
+++ b/lib/style_elmatica/version.rb
@@ -1,3 +1,3 @@
 module StyleElmatica
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
Why: so that we can decide how to deal with unused arguments inside method calls