### PR TITLE
#176573803 - Chore: Disable trailing underscore cop

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -39,6 +39,9 @@ Style/SymbolArray:
 Style/NumericLiterals:
   Enabled: false
 
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 

--- a/lib/style_elmatica/version.rb
+++ b/lib/style_elmatica/version.rb
@@ -1,3 +1,3 @@
 module StyleElmatica
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
Why: so that we an keep trailing underscore variables, and keep the code more readable