### PR TITLE
#176573803 - Chore: Additional rufo x rubocop conflict changes

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -273,6 +273,9 @@ Layout/ArgumentAlignment:
 Layout/FirstArgumentIndentation:
   Enabled: false
 
+Layout/BeginEndAlignment:
+  Enabled: false
+
 Style/Semicolon:
   Enabled: false
 

--- a/lib/style_elmatica/version.rb
+++ b/lib/style_elmatica/version.rb
@@ -1,3 +1,3 @@
 module StyleElmatica
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
Disable end alignment cop: so that we can allow rufo solely to handle this, and avoid conflicts with rubcop